### PR TITLE
Add user auth with Supabase

### DIFF
--- a/trokke/src/app/api/signup/route.ts
+++ b/trokke/src/app/api/signup/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  process.env.NEXT_PUBLIC_SUPABASE_URL!,
+  process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  { auth: { persistSession: false } }
+)
+
+export async function POST(req: NextRequest) {
+  const { fullName, email, password } = await req.json()
+
+  const { data: signUpData, error: signUpError } = await supabase.auth.signUp({
+    email,
+    password
+  })
+
+  if (signUpError || !signUpData.user) {
+    return NextResponse.json(
+      { error: signUpError?.message || 'Failed to sign up' },
+      { status: 400 }
+    )
+  }
+
+  const userId = signUpData.user.id
+
+  const { error: profileError } = await supabase.from('profiles').insert({
+    id: userId,
+    full_name: fullName,
+    role: 'client'
+  })
+
+  if (profileError) {
+    return NextResponse.json(
+      { error: profileError.message },
+      { status: 400 }
+    )
+  }
+
+  const { error: clientError } = await supabase.from('clients').insert({
+    profile_id: userId
+  })
+
+  if (clientError) {
+    return NextResponse.json(
+      { error: clientError.message },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/trokke/src/app/dashboard/page.tsx
+++ b/trokke/src/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <h1 className="text-2xl font-semibold">Dashboard</h1>
+    </div>
+  )
+}

--- a/trokke/src/app/login/page.tsx
+++ b/trokke/src/app/login/page.tsx
@@ -1,0 +1,50 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '@/utils/supabase'
+import { useRouter } from 'next/navigation'
+
+export default function LoginPage() {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/dashboard')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
+      <h1 className="text-2xl font-semibold">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-80">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="p-2 bg-blue-600 text-white rounded">
+          Login
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/trokke/src/app/signup/page.tsx
+++ b/trokke/src/app/signup/page.tsx
@@ -1,0 +1,72 @@
+'use client'
+
+import { useState } from 'react'
+import { supabase } from '@/utils/supabase'
+import { useRouter } from 'next/navigation'
+
+export default function SignupPage() {
+  const router = useRouter()
+  const [fullName, setFullName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    const res = await fetch('/api/signup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ fullName, email, password })
+    })
+
+    if (!res.ok) {
+      const data = await res.json()
+      setError(data.error || 'Sign up failed')
+      return
+    }
+
+    const { error } = await supabase.auth.signInWithPassword({ email, password })
+    if (error) {
+      setError(error.message)
+    } else {
+      router.push('/dashboard')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
+      <h1 className="text-2xl font-semibold">Sign Up</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4 w-80">
+        <input
+          type="text"
+          placeholder="Full Name"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="p-2 border rounded"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="p-2 bg-blue-600 text-white rounded">
+          Sign Up
+        </button>
+      </form>
+    </div>
+  )
+}

--- a/trokke/src/utils/supabase.ts
+++ b/trokke/src/utils/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- setup Supabase client
- add login page
- add signup page and API route to create profiles/clients
- add simple dashboard page

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878b66e2e708331a1200effe4db327b