### PR TITLE
Add admin client store management

### DIFF
--- a/trokke/src/app/admin/clients/[id]/page.tsx
+++ b/trokke/src/app/admin/clients/[id]/page.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { useEffect, useState, FormEvent } from 'react'
+import { supabase } from '@/lib/supabase'
+
+interface Client {
+  id: string
+  company_name: string
+  profiles: { full_name: string } | null
+}
+
+interface Store {
+  id: number
+  name: string
+  address: string
+}
+
+export default function ClientStoresPage({ params }: { params: { id: string } }) {
+  const clientId = params.id
+  const [client, setClient] = useState<Client | null>(null)
+  const [stores, setStores] = useState<Store[]>([])
+  const [name, setName] = useState('')
+  const [address, setAddress] = useState('')
+
+  useEffect(() => {
+    const load = async () => {
+      const { data: clientData } = await supabase
+        .from('clients')
+        .select('id, company_name, profiles(full_name)')
+        .eq('id', clientId)
+        .single()
+      setClient(clientData)
+
+      const { data: storeData } = await supabase
+        .from('client_stores')
+        .select('*')
+        .eq('client_id', clientId)
+      setStores(storeData || [])
+    }
+    load()
+  }, [clientId])
+
+  const addStore = async (e: FormEvent) => {
+    e.preventDefault()
+    const { data, error } = await supabase
+      .from('client_stores')
+      .insert({ name, address, client_id: clientId })
+      .select()
+      .single()
+    if (!error && data) {
+      setStores([...stores, data])
+      setName('')
+      setAddress('')
+    }
+  }
+
+  const updateStore = async (id: number, field: keyof Store, value: string) => {
+    const { error } = await supabase
+      .from('client_stores')
+      .update({ [field]: value })
+      .eq('id', id)
+    if (!error) {
+      setStores((prev) => prev.map((s) => (s.id === id ? { ...s, [field]: value } : s)))
+    }
+  }
+
+  const deleteStore = async (id: number) => {
+    const { error } = await supabase.from('client_stores').delete().eq('id', id)
+    if (!error) {
+      setStores((prev) => prev.filter((s) => s.id !== id))
+    }
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      {client && (
+        <div>
+          <h1 className="text-xl font-bold">{client.profiles?.full_name}</h1>
+          <p className="text-gray-600">{client.company_name}</p>
+        </div>
+      )}
+
+      <div>
+        <h2 className="text-lg font-bold mb-2">Stores</h2>
+        <ul className="space-y-2 mb-4">
+          {stores.map((store) => (
+            <li key={store.id} className="border p-2 rounded">
+              <input
+                className="border p-1 mr-2"
+                value={store.name}
+                onChange={(e) => updateStore(store.id, 'name', e.target.value)}
+              />
+              <input
+                className="border p-1 mr-2"
+                value={store.address}
+                onChange={(e) => updateStore(store.id, 'address', e.target.value)}
+              />
+              <button className="text-red-600" onClick={() => deleteStore(store.id)}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+        <form onSubmit={addStore} className="space-y-2">
+          <input
+            className="border p-1 block w-full"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <input
+            className="border p-1 block w-full"
+            placeholder="Address"
+            value={address}
+            onChange={(e) => setAddress(e.target.value)}
+            required
+          />
+          <button type="submit" className="bg-blue-600 text-white px-4 py-1 rounded">
+            Add Store
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/trokke/src/app/admin/clients/page.tsx
+++ b/trokke/src/app/admin/clients/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import Link from 'next/link'
+import { supabase } from '@/lib/supabase'
+
+interface Client {
+  id: string
+  company_name: string
+  profiles: { full_name: string } | null
+}
+
+export default function AdminClientsPage() {
+  const [clients, setClients] = useState<Client[]>([])
+
+  useEffect(() => {
+    const load = async () => {
+      const { data, error } = await supabase
+        .from('clients')
+        .select('id, company_name, profiles(full_name)')
+      if (!error && data) {
+        setClients(data)
+      }
+    }
+    load()
+  }, [])
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold mb-4">Clients</h1>
+      <ul className="space-y-2">
+        {clients.map((client) => (
+          <li key={client.id}>
+            <Link href={`/admin/clients/${client.id}`} className="text-blue-600 underline">
+              {client.profiles?.full_name} - {client.company_name}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/trokke/src/lib/supabase.ts
+++ b/trokke/src/lib/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string
+
+export const supabase = createClient(supabaseUrl, supabaseKey)


### PR DESCRIPTION
## Summary
- add supabase client util
- add page to list clients for the admin
- add client-specific page with CRUD for stores

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6878b6810cb48331aeba0a8f7793812c