### PR TITLE
Add auth and truck admin CRUD pages

### DIFF
--- a/trokke/src/app/admin/trucks/page.tsx
+++ b/trokke/src/app/admin/trucks/page.tsx
@@ -1,0 +1,83 @@
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+async function getData() {
+  const { data: trucks } = await supabaseAdmin.from('trucks').select('*');
+  const { data: workers } = await supabaseAdmin
+    .from('workers')
+    .select('id, profiles(full_name)');
+  return { trucks: trucks || [], workers: workers || [] };
+}
+
+export default async function TrucksPage() {
+  const { trucks, workers } = await getData();
+
+  async function create(formData: FormData) {
+    'use server';
+    const license_plate = formData.get('license_plate') as string;
+    const make = formData.get('make') as string;
+    const model = formData.get('model') as string;
+    const year = Number(formData.get('year'));
+    await supabaseAdmin.from('trucks').insert({ license_plate, make, model, year });
+  }
+
+  async function update(formData: FormData) {
+    'use server';
+    const id = formData.get('id') as string;
+    const license_plate = formData.get('license_plate') as string;
+    const make = formData.get('make') as string;
+    const model = formData.get('model') as string;
+    const year = Number(formData.get('year'));
+    const assigned_worker_id = formData.get('assigned_worker_id') as string | null;
+    await supabaseAdmin
+      .from('trucks')
+      .update({ license_plate, make, model, year, assigned_worker_id })
+      .eq('id', id);
+  }
+
+  async function remove(formData: FormData) {
+    'use server';
+    const id = formData.get('id') as string;
+    await supabaseAdmin.from('trucks').delete().eq('id', id);
+  }
+
+  return (
+    <div className="p-4 space-y-6">
+      <h1 className="text-xl mb-2">Trucks</h1>
+      <form action={create} className="space-y-2 border p-3">
+        <h2>Create Truck</h2>
+        <input name="license_plate" placeholder="License Plate" className="border p-1" required />
+        <input name="make" placeholder="Make" className="border p-1" required />
+        <input name="model" placeholder="Model" className="border p-1" required />
+        <input name="year" placeholder="Year" type="number" className="border p-1" required />
+        <button type="submit" className="bg-blue-600 text-white px-2 py-1">Create</button>
+      </form>
+      <ul className="space-y-4">
+        {trucks.map((truck) => (
+          <li key={truck.id} className="border p-3">
+            <form action={update} className="space-y-2">
+              <input type="hidden" name="id" value={truck.id} />
+              <input name="license_plate" defaultValue={truck.license_plate} className="border p-1" />
+              <input name="make" defaultValue={truck.make} className="border p-1" />
+              <input name="model" defaultValue={truck.model} className="border p-1" />
+              <input name="year" type="number" defaultValue={truck.year} className="border p-1" />
+              <select name="assigned_worker_id" defaultValue={truck.assigned_worker_id || ''} className="border p-1">
+                <option value="">Unassigned</option>
+                {workers.map((w) => (<option key={w.id} value={w.id}>{w.profiles.full_name}</option>))}
+              </select>
+              <div className="flex gap-2">
+                <button type="submit" className="bg-green-600 text-white px-2 py-1">
+                  Save
+                </button>
+              </div>
+            </form>
+                <form action={remove} className="mt-1">
+                  <input type="hidden" name="id" value={truck.id} />
+                  <button type="submit" className="bg-red-600 text-white px-2 py-1">Delete</button>
+                </form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+

--- a/trokke/src/app/api/signup/route.ts
+++ b/trokke/src/app/api/signup/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+export async function POST(request: Request) {
+  const { email, password, fullName } = await request.json();
+  const { data: userRes, error: userError } = await supabaseAdmin.auth.admin.createUser({
+    email,
+    password,
+    email_confirm: true,
+  });
+  if (userError || !userRes?.user) {
+    return NextResponse.json({ error: userError?.message }, { status: 400 });
+  }
+  const userId = userRes.user.id;
+  const { error: profileError } = await supabaseAdmin.from('profiles').insert({
+    id: userId,
+    full_name: fullName,
+    role: 'client',
+  });
+  if (profileError) {
+    return NextResponse.json({ error: profileError.message }, { status: 400 });
+  }
+  const { error: clientError } = await supabaseAdmin.from('clients').insert({
+    profile_id: userId,
+  });
+  if (clientError) {
+    return NextResponse.json({ error: clientError.message }, { status: 400 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/trokke/src/app/dashboard/page.tsx
+++ b/trokke/src/app/dashboard/page.tsx
@@ -1,0 +1,7 @@
+export default function DashboardPage() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl">Dashboard</h1>
+    </div>
+  );
+}

--- a/trokke/src/app/login/page.tsx
+++ b/trokke/src/app/login/page.tsx
@@ -1,0 +1,49 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      router.push('/dashboard');
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Login</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-600 text-white p-2">
+          Login
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/trokke/src/app/signup/page.tsx
+++ b/trokke/src/app/signup/page.tsx
@@ -1,0 +1,69 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function SignupPage() {
+  const router = useRouter();
+  const [fullName, setFullName] = useState('');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/signup', {
+      method: 'POST',
+      body: JSON.stringify({ email, password, fullName }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error || 'Error signing up');
+      return;
+    }
+    const { error: loginError } = await supabase.auth.signInWithPassword({ email, password });
+    if (loginError) {
+      setError(loginError.message);
+    } else {
+      router.push('/dashboard');
+    }
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <h1 className="text-xl mb-4">Sign Up</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <input
+          type="text"
+          placeholder="Full Name"
+          value={fullName}
+          onChange={(e) => setFullName(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="border p-2"
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="bg-blue-600 text-white p-2">
+          Sign Up
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/trokke/src/lib/supabaseAdmin.ts
+++ b/trokke/src/lib/supabaseAdmin.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string;
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceKey);

--- a/trokke/src/lib/supabaseClient.ts
+++ b/trokke/src/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- add Supabase clients for browser and service role
- implement signup API creating user, profile, and client records
- create login and signup pages that use Supabase auth
- add simple dashboard page
- build admin trucks page with create/update/delete and worker assignment

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878b673f6dc8331a5fa28a1a0b12a39