### PR TITLE
Add auth and sidebar navigation

### DIFF
--- a/trokke/src/app/dashboard/page.tsx
+++ b/trokke/src/app/dashboard/page.tsx
@@ -1,0 +1,26 @@
+'use client';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { useAuth } from '@/components/AuthProvider';
+
+export default function Dashboard() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.replace('/login');
+    }
+  }, [user, loading, router]);
+
+  if (!user) {
+    return <p className="p-4">Loading...</p>;
+  }
+
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold mb-4">Dashboard</h1>
+      <p>Welcome, {user.email}</p>
+    </div>
+  );
+}

--- a/trokke/src/app/globals.css
+++ b/trokke/src/app/globals.css
@@ -8,8 +8,6 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/trokke/src/app/layout.tsx
+++ b/trokke/src/app/layout.tsx
@@ -1,16 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
+import { AuthProvider } from "@/components/AuthProvider";
+import SideNav from "@/components/SideNav";
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,10 +15,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className="antialiased">
+        <AuthProvider>
+          <div className="flex min-h-screen">
+            <SideNav />
+            <main className="flex-1 p-4">{children}</main>
+          </div>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/trokke/src/app/login/page.tsx
+++ b/trokke/src/app/login/page.tsx
@@ -1,0 +1,48 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/utils/supabase';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const { error } = await supabase.auth.signInWithPassword({ email, password });
+    if (error) {
+      setError(error.message);
+    } else {
+      router.push('/dashboard');
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-center min-h-screen w-full">
+      <form onSubmit={handleSubmit} className="bg-white p-6 rounded shadow w-80 space-y-4">
+        <h1 className="text-xl font-bold">Login</h1>
+        {error && <p className="text-red-500">{error}</p>}
+        <input
+          type="email"
+          placeholder="Email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          className="w-full border p-2"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full border p-2"
+        />
+        <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded w-full">
+          Sign In
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/trokke/src/components/AuthProvider.tsx
+++ b/trokke/src/components/AuthProvider.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { createContext, useContext, useEffect, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { supabase } from '@/utils/supabase';
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null, loading: true });
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getUser().then(({ data }) => {
+      setUser(data.user ?? null);
+      setLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((_, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>{children}</AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/trokke/src/components/SideNav.tsx
+++ b/trokke/src/components/SideNav.tsx
@@ -1,0 +1,38 @@
+'use client';
+import Link from 'next/link';
+import { useAuth } from './AuthProvider';
+import { supabase } from '@/utils/supabase';
+
+export default function SideNav() {
+  const { user } = useAuth();
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut();
+  };
+
+  return (
+    <nav className="w-48 min-h-screen border-r p-4">
+      <ul className="space-y-2">
+        <li>
+          <Link href="/">Home</Link>
+        </li>
+        {user && (
+          <li>
+            <Link href="/dashboard">Dashboard</Link>
+          </li>
+        )}
+        {user ? (
+          <li>
+            <button onClick={handleLogout} className="text-left w-full">
+              Logout
+            </button>
+          </li>
+        ) : (
+          <li>
+            <Link href="/login">Login</Link>
+          </li>
+        )}
+      </ul>
+    </nav>
+  );
+}

--- a/trokke/src/utils/supabase.ts
+++ b/trokke/src/utils/supabase.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- add Supabase client helper
- provide `AuthProvider` and `SideNav` components
- include sidebar navigation in the layout
- add login form page
- protect dashboard page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6878ba736cb48331ab6e2f831874a058