### PR TITLE
Implement auth context and sidebar navigation

### DIFF
--- a/trokke/src/app/layout.tsx
+++ b/trokke/src/app/layout.tsx
@@ -1,6 +1,9 @@
-import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
-import "./globals.css";
+import type { Metadata } from "next"
+import { Geist, Geist_Mono } from "next/font/google"
+import "./globals.css"
+import { AuthProvider } from "@/components/AuthContext"
+import Sidebar from "@/components/Sidebar"
+import AuthGate from "@/components/AuthGate"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -24,10 +27,13 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        {children}
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex`}>
+        <AuthProvider>
+          <Sidebar />
+          <AuthGate>
+            <main className="flex-1 ml-60 p-4">{children}</main>
+          </AuthGate>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/trokke/src/app/login/page.tsx
+++ b/trokke/src/app/login/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { supabase } from '@/utils/supabase'
+import supabase from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 
 export default function LoginPage() {

--- a/trokke/src/app/signup/page.tsx
+++ b/trokke/src/app/signup/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { supabase } from '@/utils/supabase'
+import supabase from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
 
 export default function SignupPage() {

--- a/trokke/src/components/AuthContext.tsx
+++ b/trokke/src/components/AuthContext.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react'
+import { Session } from '@supabase/supabase-js'
+import supabase from '@/lib/supabaseClient'
+
+interface AuthContextValue {
+  session: Session | null
+}
+
+const AuthContext = createContext<AuthContextValue>({ session: null })
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [session, setSession] = useState<Session | null>(null)
+
+  useEffect(() => {
+    const getSession = async () => {
+      const { data } = await supabase.auth.getSession()
+      setSession(data.session)
+    }
+
+    getSession()
+
+    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+      setSession(session)
+    })
+
+    return () => {
+      listener.subscription?.unsubscribe()
+    }
+  }, [])
+
+  return <AuthContext.Provider value={{ session }}>{children}</AuthContext.Provider>
+}
+
+export const useAuth = () => useContext(AuthContext)
+
+export default AuthContext

--- a/trokke/src/components/AuthGate.tsx
+++ b/trokke/src/components/AuthGate.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+import { usePathname, useRouter } from 'next/navigation'
+import { useAuth } from './AuthContext'
+
+export default function AuthGate({ children }: { children: React.ReactNode }) {
+  const { session } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname()
+
+  useEffect(() => {
+    const publicPaths = ['/login', '/signup']
+    if (!session && !publicPaths.includes(pathname)) {
+      router.replace('/login')
+    }
+  }, [session, pathname, router])
+
+  return <>{children}</>
+}

--- a/trokke/src/components/Sidebar.tsx
+++ b/trokke/src/components/Sidebar.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import supabase from '@/lib/supabaseClient'
+import { useAuth } from './AuthContext'
+
+const navItems = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/admin/dashboard', label: 'Map' },
+  { href: '/admin/trucks', label: 'Trucks' },
+  { href: '/admin/clients', label: 'Clients' },
+  { href: '/admin/business-stores', label: 'Stores' },
+]
+
+export default function Sidebar() {
+  const { session } = useAuth()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  if (!session) return null
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.push('/login')
+  }
+
+  return (
+    <aside className="w-60 h-screen fixed left-0 top-0 bg-gray-100 p-4 space-y-2 overflow-y-auto">
+      <nav className="flex flex-col space-y-1">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`p-2 rounded hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : ''}`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      <button
+        onClick={handleLogout}
+        className="mt-4 p-2 w-full text-left bg-red-500 text-white rounded"
+      >
+        Logout
+      </button>
+    </aside>
+  )
+}


### PR DESCRIPTION
## Summary
- add `AuthProvider`, `AuthGate`, and `Sidebar` components
- update layout to include sidebar and session management
- use the shared `supabaseClient` for auth pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878bb8be36883319e6348591f774cad