### PR TITLE
Improve navigation and signup/login UX

### DIFF
--- a/trokke/src/app/layout.tsx
+++ b/trokke/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
 import { AuthProvider } from "@/components/AuthContext"
 import Sidebar from "@/components/Sidebar"
+import Navbar from "@/components/Navbar"
 import AuthGate from "@/components/AuthGate"
 
 const geistSans = Geist({
@@ -30,8 +31,9 @@ export default function RootLayout({
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex`}>
         <AuthProvider>
           <Sidebar />
+          <Navbar />
           <AuthGate>
-            <main className="flex-1 ml-60 p-4">{children}</main>
+            <main className="flex-1 ml-60 pt-14 p-4">{children}</main>
           </AuthGate>
         </AuthProvider>
       </body>

--- a/trokke/src/app/login/page.tsx
+++ b/trokke/src/app/login/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import supabase from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
 export default function LoginPage() {
   const router = useRouter()
@@ -45,6 +46,10 @@ export default function LoginPage() {
           Login
         </button>
       </form>
+      <p className="text-sm">
+        Don&apos;t have an account?{' '}
+        <Link href="/signup" className="text-blue-600 underline">Sign up</Link>
+      </p>
     </div>
   )
 }

--- a/trokke/src/app/signup/page.tsx
+++ b/trokke/src/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import supabase from '@/lib/supabaseClient'
 import { useRouter } from 'next/navigation'
+import Link from 'next/link'
 
 export default function SignupPage() {
   const router = useRouter()
@@ -67,6 +68,10 @@ export default function SignupPage() {
           Sign Up
         </button>
       </form>
+      <p className="text-sm">
+        Already have an account?{' '}
+        <Link href="/login" className="text-blue-600 underline">Sign in</Link>
+      </p>
     </div>
   )
 }

--- a/trokke/src/components/Navbar.tsx
+++ b/trokke/src/components/Navbar.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname, useRouter } from 'next/navigation'
+import supabase from '@/lib/supabaseClient'
+import { useAuth } from './AuthContext'
+
+const navItems = [
+  { href: '/dashboard', label: 'Dashboard' },
+  { href: '/admin/dashboard', label: 'Map' },
+  { href: '/admin/trucks', label: 'Trucks' },
+  { href: '/admin/clients', label: 'Clients' },
+  { href: '/admin/business-stores', label: 'Stores' },
+]
+
+export default function Navbar() {
+  const { session } = useAuth()
+  const pathname = usePathname()
+  const router = useRouter()
+
+  if (!session) return null
+
+  const handleLogout = async () => {
+    await supabase.auth.signOut()
+    router.push('/login')
+  }
+
+  return (
+    <header className="fixed top-0 left-0 right-0 h-12 bg-gray-100 flex items-center px-4 shadow z-10 ml-60">
+      <nav className="flex gap-4 flex-1">
+        {navItems.map((item) => (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`py-2 px-3 rounded hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : ''}`}
+          >
+            {item.label}
+          </Link>
+        ))}
+      </nav>
+      <button
+        onClick={handleLogout}
+        className="p-2 bg-red-500 text-white rounded"
+      >
+        Logout
+      </button>
+    </header>
+  )
+}


### PR DESCRIPTION
## Summary
- add a top Navbar with links to all admin sections and logout
- integrate Navbar in the root layout
- link signup and login pages together for easier navigation

## Testing
- `npm run lint`
- `npm run build` *(fails: unable to fetch fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6878be2da0e0833180a5bdeb7a8c774b