### PR TITLE
Implement wrapper layout

### DIFF
--- a/trokke/src/app/layout.tsx
+++ b/trokke/src/app/layout.tsx
@@ -1,10 +1,7 @@
 import type { Metadata } from "next"
 import { Geist, Geist_Mono } from "next/font/google"
 import "./globals.css"
-import { AuthProvider } from "@/components/AuthContext"
-import Sidebar from "@/components/Sidebar"
-import Navbar from "@/components/Navbar"
-import AuthGate from "@/components/AuthGate"
+import AppWrapper from "@/components/AppWrapper"
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,13 +26,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased flex`}>
-        <AuthProvider>
-          <Sidebar />
-          <Navbar />
-          <AuthGate>
-            <main className="flex-1 ml-60 pt-14 p-4">{children}</main>
-          </AuthGate>
-        </AuthProvider>
+        <AppWrapper>{children}</AppWrapper>
       </body>
     </html>
   );

--- a/trokke/src/app/page.tsx
+++ b/trokke/src/app/page.tsx
@@ -1,103 +1,31 @@
-import Image from "next/image";
+'use client'
+
+import Link from 'next/link'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/components/AuthContext'
 
 export default function Home() {
-  return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
-      <main className="flex flex-col gap-[32px] row-start-2 items-center sm:items-start">
-        <Image
-          className="dark:invert"
-          src="/next.svg"
-          alt="Next.js logo"
-          width={180}
-          height={38}
-          priority
-        />
-        <ol className="font-mono list-inside list-decimal text-sm/6 text-center sm:text-left">
-          <li className="mb-2 tracking-[-.01em]">
-            Get started by editing{" "}
-            <code className="bg-black/[.05] dark:bg-white/[.06] font-mono font-semibold px-1 py-0.5 rounded">
-              src/app/page.tsx
-            </code>
-            .
-          </li>
-          <li className="tracking-[-.01em]">
-            Save and see your changes instantly.
-          </li>
-        </ol>
+  const { session } = useAuth()
+  const router = useRouter()
 
-        <div className="flex gap-4 items-center flex-col sm:flex-row">
-          <a
-            className="rounded-full border border-solid border-transparent transition-colors flex items-center justify-center bg-foreground text-background gap-2 hover:bg-[#383838] dark:hover:bg-[#ccc] font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 sm:w-auto"
-            href="https://vercel.com/new?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Image
-              className="dark:invert"
-              src="/vercel.svg"
-              alt="Vercel logomark"
-              width={20}
-              height={20}
-            />
-            Deploy now
-          </a>
-          <a
-            className="rounded-full border border-solid border-black/[.08] dark:border-white/[.145] transition-colors flex items-center justify-center hover:bg-[#f2f2f2] dark:hover:bg-[#1a1a1a] hover:border-transparent font-medium text-sm sm:text-base h-10 sm:h-12 px-4 sm:px-5 w-full sm:w-auto md:w-[158px]"
-            href="https://nextjs.org/docs?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Read our docs
-          </a>
-        </div>
-      </main>
-      <footer className="row-start-3 flex gap-[24px] flex-wrap items-center justify-center">
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org/learn?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/file.svg"
-            alt="File icon"
-            width={16}
-            height={16}
-          />
-          Learn
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://vercel.com/templates?framework=next.js&utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/window.svg"
-            alt="Window icon"
-            width={16}
-            height={16}
-          />
-          Examples
-        </a>
-        <a
-          className="flex items-center gap-2 hover:underline hover:underline-offset-4"
-          href="https://nextjs.org?utm_source=create-next-app&utm_medium=appdir-template-tw&utm_campaign=create-next-app"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Image
-            aria-hidden
-            src="/globe.svg"
-            alt="Globe icon"
-            width={16}
-            height={16}
-          />
-          Go to nextjs.org →
-        </a>
-      </footer>
+  useEffect(() => {
+    if (session) {
+      router.replace('/dashboard')
+    }
+  }, [session, router])
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4 p-4">
+      <h1 className="text-2xl font-semibold">Welcome to Trokke</h1>
+      <div className="flex gap-4">
+        <Link href="/login" className="p-2 bg-blue-600 text-white rounded">
+          Login
+        </Link>
+        <Link href="/signup" className="p-2 bg-gray-200 rounded">
+          Sign Up
+        </Link>
+      </div>
     </div>
-  );
+  )
 }

--- a/trokke/src/components/AppWrapper.tsx
+++ b/trokke/src/components/AppWrapper.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { AuthProvider } from '@/components/AuthContext'
+import AuthGate from '@/components/AuthGate'
+import Sidebar from '@/components/Sidebar'
+import Navbar from '@/components/Navbar'
+
+export default function AppWrapper({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return (
+    <AuthProvider>
+      <Sidebar />
+      <Navbar />
+      <AuthGate>
+        <main className="flex-1 ml-60 pt-14 p-4">{children}</main>
+      </AuthGate>
+    </AuthProvider>
+  )
+}

--- a/trokke/src/components/AuthGate.tsx
+++ b/trokke/src/components/AuthGate.tsx
@@ -10,7 +10,7 @@ export default function AuthGate({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
 
   useEffect(() => {
-    const publicPaths = ['/login', '/signup']
+    const publicPaths = ['/', '/login', '/signup']
     if (!session && !publicPaths.includes(pathname)) {
       router.replace('/login')
     }


### PR DESCRIPTION
## Summary
- move auth and navigation components into new `AppWrapper`
- use the wrapper from `layout.tsx`
- allow home page navigation and redirect authenticated users
- make root page accessible without authentication

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878c08341388331b8e34314aa102748