### PR TITLE
Fix Google Maps load errors and improve navbar

### DIFF
--- a/trokke/src/app/admin/business-stores/page.tsx
+++ b/trokke/src/app/admin/business-stores/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { supabase } from '@/lib/supabaseClient';
-import { LoadScript, Autocomplete } from '@react-google-maps/api';
+import { useJsApiLoader, Autocomplete } from '@react-google-maps/api';
 
 interface Store {
   id: number;
@@ -61,6 +61,14 @@ export default function BusinessStoresPage() {
   const [editLat, setEditLat] = useState<number | null>(null);
   const [editLng, setEditLng] = useState<number | null>(null);
 
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string,
+    libraries: ['places'],
+  });
+
+  if (!isLoaded) return <div>Loading...</div>;
+
   const handleEditPlace = () => {
     if (!editAutoRef.current) return;
     const place = editAutoRef.current.getPlace();
@@ -102,8 +110,7 @@ export default function BusinessStoresPage() {
     <div className="p-4 space-y-6">
       <h1 className="text-2xl font-bold">Business Stores</h1>
 
-      <LoadScript googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string} libraries={['places']}>
-        <form onSubmit={handleCreate} className="space-y-2">
+      <form onSubmit={handleCreate} className="space-y-2">
           <div>
             <label className="block">Name</label>
             <input
@@ -128,13 +135,11 @@ export default function BusinessStoresPage() {
           <input type="hidden" value={lng ?? ''} name="longitude" />
           <button className="bg-blue-600 text-white px-4 py-2" type="submit">Add Store</button>
         </form>
-      </LoadScript>
 
       <ul className="space-y-4">
         {stores.map((store) => (
           <li key={store.id} className="border p-4">
             {editingId === store.id ? (
-              <LoadScript googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY as string} libraries={['places']}>
                 <form onSubmit={saveEdit} className="space-y-2">
                   <div>
                     <label className="block">Name</label>
@@ -165,7 +170,6 @@ export default function BusinessStoresPage() {
                     </button>
                   </div>
                 </form>
-              </LoadScript>
             ) : (
               <div className="space-y-2">
                 <p className="font-semibold">{store.name}</p>

--- a/trokke/src/app/admin/dashboard/page.tsx
+++ b/trokke/src/app/admin/dashboard/page.tsx
@@ -5,7 +5,7 @@ import {
   GoogleMap,
   MarkerF,
   InfoWindowF,
-  LoadScript,
+  useJsApiLoader,
 } from '@react-google-maps/api';
 import supabase from '@/lib/supabaseClient';
 
@@ -59,9 +59,15 @@ export default function Dashboard() {
 
   const mapCenter = { lat: trucks[0]?.latitude || 0, lng: trucks[0]?.longitude || 0 };
 
+  const { isLoaded } = useJsApiLoader({
+    id: 'google-map-script',
+    googleMapsApiKey: process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!,
+  });
+
+  if (!isLoaded) return <div>Loading...</div>;
+
   return (
     <div className="w-full h-[80vh]">
-      <LoadScript googleMapsApiKey={process.env.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY!}>
         <GoogleMap
           mapContainerStyle={{ width: '100%', height: '100%' }}
           zoom={8}
@@ -115,7 +121,6 @@ export default function Dashboard() {
             </InfoWindowF>
           )}
         </GoogleMap>
-      </LoadScript>
     </div>
   );
 }

--- a/trokke/src/components/Navbar.tsx
+++ b/trokke/src/components/Navbar.tsx
@@ -26,13 +26,13 @@ export default function Navbar() {
   }
 
   return (
-    <header className="fixed top-0 left-0 right-0 h-12 bg-gray-100 flex items-center px-4 shadow z-10 ml-60">
+    <header className="fixed top-0 left-0 right-0 h-16 bg-gray-100 flex items-center px-6 shadow z-10 ml-60 text-black">
       <nav className="flex gap-4 flex-1">
         {navItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
-            className={`py-2 px-3 rounded hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : ''}`}
+            className={`py-3 px-5 rounded text-lg hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : 'text-black'}`}
           >
             {item.label}
           </Link>
@@ -40,7 +40,7 @@ export default function Navbar() {
       </nav>
       <button
         onClick={handleLogout}
-        className="p-2 bg-red-500 text-white rounded"
+        className="py-3 px-5 bg-red-500 text-white rounded text-lg"
       >
         Logout
       </button>

--- a/trokke/src/components/Sidebar.tsx
+++ b/trokke/src/components/Sidebar.tsx
@@ -26,13 +26,13 @@ export default function Sidebar() {
   }
 
   return (
-    <aside className="w-60 h-screen fixed left-0 top-0 bg-gray-100 p-4 space-y-2 overflow-y-auto">
+    <aside className="w-60 h-screen fixed left-0 top-0 bg-gray-100 text-black p-4 space-y-2 overflow-y-auto">
       <nav className="flex flex-col space-y-1">
         {navItems.map((item) => (
           <Link
             key={item.href}
             href={item.href}
-            className={`p-2 rounded hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : ''}`}
+            className={`p-2 rounded hover:bg-gray-200 ${pathname === item.href ? 'bg-blue-600 text-white' : 'text-black'}`}
           >
             {item.label}
           </Link>


### PR DESCRIPTION
## Summary
- use `useJsApiLoader` hook so Google Maps API is only loaded once
- adjust business store page accordingly
- enlarge navbar and buttons and ensure text color contrast
- set sidebar to always use black text on white background

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6878c710c5588331b9e72de96f891412